### PR TITLE
disable doxygen searchengine and latex generation

### DIFF
--- a/src/rosdoc_lite/templates/doxy.template
+++ b/src/rosdoc_lite/templates/doxy.template
@@ -1191,7 +1191,7 @@ MATHJAX_EXTENSIONS     =
 # typically be disabled. For large projects the javascript based search engine
 # can be slow, then enabling SERVER_BASED_SEARCH may provide a better solution.
 
-SEARCHENGINE           = YES
+SEARCHENGINE           = NO
 
 # When the SERVER_BASED_SEARCH tag is enabled the search engine will be
 # implemented using a PHP enabled web server instead of at the web client
@@ -1210,7 +1210,7 @@ SERVER_BASED_SEARCH    = NO
 # If the GENERATE_LATEX tag is set to YES (the default) Doxygen will
 # generate Latex output.
 
-GENERATE_LATEX         = YES
+GENERATE_LATEX         = NO
 
 # The LATEX_OUTPUT tag is used to specify where the LaTeX docs will be put.
 # If a relative path is entered the value of OUTPUT_DIRECTORY will be


### PR DESCRIPTION
The current API docs for Groovy are around **26 GB**.

By removing the generated searchengine in doxygen (the small search box in the top right corner at e.g. http://docs.ros.org/hydro/api/roscpp/html/index.html) the amount would be significantly reduced to **6.9 GB**.

Additionally I am not sure why we generate latex docs in the first place (e.g. http://docs.ros.org/hydro/api/roscpp/html/latex/) - likely because it is the default in doxygen. By disabling this we another 20% in size resulting in only **5.7 GB**.

After this has been merged (and all doc jobs have been executed) it must be verified that the already available generated search/latex documentation is actually removed form the server.
