### PR TITLE
Enable XML output for sphinx breathe plugin

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,7 @@
   <run_depend>doxygen</run_depend>
   <run_depend>epydoc</run_depend>
   <run_depend>genmsg</run_depend>
+  <run_depend>python-breathe</run_depend>
   <run_depend>python-catkin-pkg</run_depend>
   <run_depend>python-kitchen</run_depend>
   <run_depend>python-rospkg</run_depend>

--- a/src/rosdoc_lite/templates/doxy.template
+++ b/src/rosdoc_lite/templates/doxy.template
@@ -1779,7 +1779,7 @@ MAN_LINKS              = NO
 # captures the structure of the code including all documentation.
 # The default value is: NO.
 
-GENERATE_XML           = NO
+GENERATE_XML           = YES
 
 # The XML_OUTPUT tag is used to specify where the XML pages will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of


### PR DESCRIPTION
The breathe plugin (https://breathe.readthedocs.org/) allows embedding doxygen's output inside sphinx, but requires that the GENERATE_XML option is turned on in the config.
