### PR TITLE
More correct reference to the package website url

### DIFF
--- a/src/rosdoc_lite/msgenator.py
+++ b/src/rosdoc_lite/msgenator.py
@@ -293,7 +293,7 @@ def generate_msg_docs(package, path, manifest, output_dir):
             raise
 
     # generate the top-level index
-    wiki_url = '<li>%s</li>\n' % _href(manifest.url, 'Wiki page for %s' % package)
-    generate_msg_index(package, output_dir, msg_success, srv_success, action_success, wiki_url, msg_index_template)
+    website_url = '<li>%s</li>\n' % _href(manifest.url, 'Website')
+    generate_msg_index(package, output_dir, msg_success, srv_success, action_success, website_url, msg_index_template)
 
     return (msg_success, srv_success, action_success)


### PR DESCRIPTION
Previously it read something like (actual link [here](http://docs.ros.org/kinetic/api/sensor_msgs/html/index-msg.html)):

```
Wiki page for sensor_msgs
```

Now it just creates the link to 'Website'.

This more appropriately syncs with the `website` attribute of the `url` tag - quite often the link is not a wiki link.