### PR TITLE
Generator for swagger rest api documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.pyc
+.project
+.pydevproject
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/rosdoc_lite/templates/swagger-ui"]
+	path = src/rosdoc_lite/templates/swagger-ui
+	url = https://github.com/swagger-api/swagger-ui.git

--- a/package.xml
+++ b/package.xml
@@ -25,6 +25,7 @@
   <run_depend>python-kitchen</run_depend>
   <run_depend>python-rospkg</run_depend>
   <run_depend>python-sphinx</run_depend>
+  <run_depend>python-termcolor</run_depend>
   <run_depend>python-yaml</run_depend>
 
   <export>

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,17 @@ d = generate_distutils_setup(
     packages=['rosdoc_lite'],
     package_dir={'': 'src'},
     scripts=['scripts/rosdoc_lite'],
-    package_data={'rosdoc_lite': ['templates/*']}
+    package_data={'rosdoc_lite': ['templates/*',
+                                  'templates/swagger-ui/*',
+                                  'templates/swagger-ui/dist/*',
+                                  'templates/swagger-ui/dist/css/*',
+                                  'templates/swagger-ui/dist/fonts/*',
+                                  'templates/swagger-ui/dist/langs/*',
+                                  'templates/swagger-ui/dist/images/*',
+                                  'templates/swagger-ui/dist/lib/*'
+                                  # skipping other swagger dirs, they are not needed
+                                  ]
+                  }
 )
 
 setup(**d)

--- a/src/rosdoc_lite/exceptions.py
+++ b/src/rosdoc_lite/exceptions.py
@@ -1,0 +1,38 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2008, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+class PluginException(Exception):
+    """
+    Generic exception for plugin errors.
+    """
+    pass

--- a/src/rosdoc_lite/msgenator.py
+++ b/src/rosdoc_lite/msgenator.py
@@ -44,9 +44,9 @@ import fnmatch
 
 def _find_files_with_extension(path, ext):
     matches = []
-    for root, dirnames, filenames in os.walk(path):
+    for root, unused_dirnames, filenames in os.walk(path):
         for filename in fnmatch.filter(filenames, '*.%s' % ext):
-            #matches.append(os.path.join(root, filename))
+            # matches.append(os.path.join(root, filename))
             matches.append((os.path.splitext(filename)[0], os.path.join(root, filename)))
     return matches
 
@@ -91,6 +91,7 @@ def index_type_link(pref, type_, base_package):
     else:
         return _href("../../%(package)s/html/%(pref)s/%(base_type_)s.html" % locals(), type_)
 
+
 def _generate_raw_text(raw_text):
     s = ''
     for line in raw_text.split('\n'):
@@ -102,19 +103,20 @@ def _generate_raw_text(raw_text):
             s = s + "%s<br/>"%parts[0]
     return s
 
+
 def _generate_msg_text_from_spec(package, spec, msg_context, buff=None, indent=0):
     if buff is None:
         buff = cStringIO.StringIO()
     for c in spec.constants:
-        buff.write("%s%s %s=%s<br />" % ("&nbsp;"*indent, c.type, c.name, c.val_text))
+        buff.write("%s%s %s=%s<br />" % ("&nbsp;" * indent, c.type, c.name, c.val_text))
     for type_, name in zip(spec.types, spec.names):
-        buff.write("%s%s %s<br />" % ("&nbsp;"*indent, type_link(type_, package), name))
+        buff.write("%s%s %s<br />" % ("&nbsp;" * indent, type_link(type_, package), name))
         base_type = genmsg.msgs.parse_type(type_)[0]
         base_type = genmsg.msgs.resolve_type(base_type, package)
-        #TODO: If you actually want an expanded definition, you need some way
+        # TODO: If you actually want an expanded definition, you need some way
         # to go from package name to message type, with the new catkin stuff,
-        #I'm not sure this is possible
-        #if not base_type in genmsg.msgs.BUILTIN_TYPES:
+        # I'm not sure this is possible
+        # if not base_type in genmsg.msgs.BUILTIN_TYPES:
         #    subspec = None
         #    if not msg_context.is_registered(base_type):
         #        package, msg_type = resource_name(base_type)
@@ -127,7 +129,7 @@ def _generate_msg_text_from_spec(package, spec, msg_context, buff=None, indent=0
 
 
 def _generate_msg_text(package, type_, msg_context, spec):
-    #print("generate", package, type_)
+    # print("generate", package, type_)
     return _generate_msg_text_from_spec(package, spec, msg_context)
 
 
@@ -135,6 +137,7 @@ def _generate_srv_text(package, type_, msg_context, spec):
     return _generate_msg_text_from_spec(package, spec.request, msg_context) + \
         '<hr />' + \
         _generate_msg_text_from_spec(package, spec.response, msg_context)
+
 
 def generate_action_doc(action, action_template, path):
     package, base_type = resource_name(action)
@@ -146,6 +149,7 @@ def generate_action_doc(action, action_template, path):
         raw_text = f.read()
     d['raw_text'] = _generate_raw_text(raw_text)
     return action_template % d
+
 
 def generate_srv_doc(srv, msg_context, msg_template, path):
     package, base_type = resource_name(srv)
@@ -201,7 +205,7 @@ def generate_msg_index(package, file_d, msgs, srvs, actions, wiki_url, msg_index
     file_p = os.path.join(file_d, 'index-msg.html')
     text = msg_index_template % d
     with open(file_p, 'w') as f:
-        #print("writing", file_p)
+        # print("writing", file_p)
         f.write(text)
 
 
@@ -222,11 +226,14 @@ def generate_msg_docs(package, path, manifest, output_dir):
     srvs = _find_files_with_extension(path, 'srv')
     actions = _find_files_with_extension(path, 'action')
 
-    print(msgs)
-    print(srvs)
-    print(actions)
+    if msgs:
+        print(msgs)
+    if srvs:
+        print(srvs)
+    if actions:
+        print(actions)
 
-    #Load template files
+    # Load template files
     msg_template = rdcore.load_tmpl('msg.template')
     action_template = rdcore.load_tmpl('action.template')
     msg_index_template = rdcore.load_tmpl('msg-index.template')
@@ -245,10 +252,10 @@ def generate_msg_docs(package, path, manifest, output_dir):
     msg_context = genmsg.msg_loader.MsgContext.create_default()
     for m, msg_path in msgs:
         try:
-            text = generate_msg_doc('%s/%s'%(package,m), msg_context, msg_template, msg_path)
+            text = generate_msg_doc('%s/%s' % (package, m), msg_context, msg_template, msg_path)
             file_p = os.path.join(msg_d, '%s.html' % m)
             with open(file_p, 'w') as f:
-                #print("writing", file_p)
+                # print("writing", file_p)
                 f.write(text)
             msg_success.append(m)
         except Exception, e:
@@ -263,29 +270,29 @@ def generate_msg_docs(package, path, manifest, output_dir):
     # document the services
     for s, srv_path in srvs:
         try:
-            text = generate_srv_doc('%s/%s' % (package,s), msg_context, msg_template, srv_path)
+            text = generate_srv_doc('%s/%s' % (package, s), msg_context, msg_template, srv_path)
             file_p = os.path.join(srv_d, '%s.html' % s)
             with open(file_p, 'w') as f:
-                #print("writing", file_p)
+                # print("writing", file_p)
                 f.write(text)
             srv_success.append(s)
         except Exception, e:
             print("FAILED to generate for %s/%s: %s" % (package, s, str(e)), file=sys.stderr)
             raise
 
-    #create dir for action documentation
+    # create dir for action documentation
     if actions:
         action_d = os.path.join(output_dir, 'action')
         if not os.path.exists(action_d):
             os.makedirs(action_d)
 
-    #document the actions
+    # document the actions
     for a, action_path in actions:
         try:
-            text = generate_action_doc('%s/%s' % (package,a), action_template, action_path)
+            text = generate_action_doc('%s/%s' % (package, a), action_template, action_path)
             file_p = os.path.join(action_d, '%s.html' % a)
             with open(file_p, 'w') as f:
-                #print("writing", file_p)
+                # print("writing", file_p)
                 f.write(text)
             action_success.append(a)
         except Exception, e:

--- a/src/rosdoc_lite/swaggernator.py
+++ b/src/rosdoc_lite/swaggernator.py
@@ -1,0 +1,198 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2016, Yujin Robot
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+from __future__ import print_function
+
+import errno
+import fnmatch
+import json
+import os
+import re
+import shutil
+import tempfile
+import termcolor
+import yaml
+
+from . import exceptions
+
+
+def generate_swagger(path, package, manifest, rd_config, output_dir, quiet):
+    """
+    Main entrypoint into creating Swagger documentation
+    """
+    ######################
+    # Configuration
+    ######################
+    env_resources_directory = os.environ.get('ROSDOC_SWAGGER_RESOURCES_DIR')  # returns None if not found
+    if 'destination_directory' in rd_config:
+        base_dir = os.path.join(path, rd_config['destination_directory']) if 'destination_directory' in rd_config else path
+    else:
+        base_dir = path
+    if env_resources_directory is not None:
+        resources_directory = env_resources_directory
+    elif 'resources_directory' in rd_config:
+        resources_directory = rd_config['resources_directory']
+    else:
+        resources_directory = os.path.join(os.path.dirname(__file__), 'templates', 'swagger-ui')
+        if not os.path.isfile(os.path.join(resources_directory, 'dist', 'index.html')):
+            raise exceptions.PluginException("swagger resources haven't been downloaded, did you 'git clone --recursive?'".format(resources_directory))
+
+    ######################
+    # Debugging
+    ######################
+    if not quiet:
+        print("")
+        termcolor.cprint("Generate Swagger", 'white', attrs=['bold'])
+        print("")
+        pretty_print_key_value("Package", package, indent=2)
+        pretty_print_key_value("Path", path, indent=2)
+        pretty_print_key_value("Manifest", manifest, indent=2)
+        pretty_print_key_value("Rosdoc config", rd_config, indent=2)
+        pretty_print_key_value("Output Dir", output_dir, indent=2)
+        pretty_print_key_value("Resources Dir", resources_directory, indent=2)
+
+    ######################
+    # Checks
+    ######################
+    if not os.path.isdir(resources_directory):
+        raise exceptions.PluginException("'{0}' does not exist.".format(resources_directory))
+
+    if not os.path.isfile(os.path.join(resources_directory, 'dist', 'index.html')):
+        raise exceptions.PluginException("'{0}' does not seem to be a valid clone/copy of the swagger-ui repository.".format(resources_directory))
+
+    yaml_filename_list = find_swagger_yaml_definitions(path)
+    ######################
+    # YAML Hunting
+    ######################
+    for yaml_filename in yaml_filename_list:
+        if not quiet:
+            pretty_print_key_value("REST API Spec", yaml_filename, indent=2)
+
+        ######################
+        # YAML 2 JSON
+        ######################
+        with open(yaml_filename, 'r') as yaml_file:
+            yaml_file_text = yaml_file.read().replace("'", "")
+            python_content = yaml.load(yaml_file_text)  # store yaml content into a dictionary
+            name = os.path.splitext(os.path.basename(yaml_filename))[0]
+        json_content = json.dumps(python_content)
+
+        ######################
+        # Generating Swagger
+        ######################
+        destination_directory = os.path.join(os.path.join(base_dir, 'html'), name)
+        create_swagger_documentation_folder(destination_directory, resources_directory)
+
+        index_html_path = os.path.join(destination_directory, 'index.html')
+
+        title_pattern = re.compile("<title>.*</title>")
+        new_title = '<title>{0}</title>'.format(name).title()
+        tmp_index_html_filehandle, tmp_index_html_path = tempfile.mkstemp()
+        with open(tmp_index_html_path, 'w') as new_html_file:
+            with open(index_html_path, 'r') as old_html_file:
+                for line in old_html_file:
+                    line = re.sub(title_pattern, new_title, line)
+                    if "dom_id" in line:
+                        new_html_file.write("        spec: JSON.parse($('#json_rest_api').html()),")
+                    if "<head>" in line:
+                        new_html_file.write('  <script id="json_rest_api" type="application/json">{0}</script>'.format(json_content))
+                    new_html_file.write(line)
+
+        os.close(tmp_index_html_filehandle)
+        os.remove(index_html_path)
+        shutil.move(tmp_index_html_path, index_html_path)
+        os.chmod(index_html_path, 0664)
+    if not quiet:
+        print("")
+
+
+def is_swagger_yaml(filename):
+    """
+    Quite a poor man's check to see whether the yaml is a swagger file or not.
+    """
+    contents = yaml.load(open(filename))
+    return (isinstance(contents, dict) and 'swagger' in contents.keys())
+
+
+def find_swagger_yaml_definitions(package_dir):
+    """
+    Walk a specified directory and its subdirectories looking for swagger
+    definition files. These are identified by:
+
+    :param str package_dir:
+    :returns [filenames]: list of swagger yaml definition filenames (absolute paths)
+    """
+
+    matches = []
+    for root, unused_dirnames, filenames in os.walk(package_dir):
+        for filename in fnmatch.filter(filenames, '*.yaml'):
+            yaml_filename = os.path.join(root, filename)
+            if is_swagger_yaml(yaml_filename):
+                matches.append(yaml_filename)
+    return matches
+
+
+def create_swagger_documentation_folder(destination_directory, resources_directory):
+    """
+    Copy all the swagger files in the templates 'swagger-ui' subfolder across to the target
+    directory (eventual doc directory).
+    :param str destination_directory: usually something like 'doc/<name of yaml>'.
+    """
+    # only use the resources from the swagger-ui dist directory
+    dist_directory = os.path.join(resources_directory, 'dist')
+    mkdir_p(destination_directory)
+    for root, dirnames, filenames in os.walk(dist_directory):
+        for d in dirnames:
+            mkdir_p(os.path.join(destination_directory, d))
+        for filename in filenames:
+            full_filename = os.path.join(root, filename)
+            if (os.path.isfile(full_filename)):
+                shutil.copy(full_filename, os.path.join(destination_directory, os.path.relpath(root, dist_directory)))
+
+
+def pretty_print_key_value(key, value, indent):
+    pretty_print_key_value_with_attributes(key, value, indent, attrs=[])
+
+
+def pretty_print_key_value_with_attributes(key, value, indent, attrs):
+    print(termcolor.colored(" " * indent + "{0: <{width}}".format(key, width=(17 - indent)), 'cyan', attrs=attrs) + ": " + termcolor.colored("{0}".format(value), 'yellow'))
+
+
+def mkdir_p(path):
+    try:
+        os.makedirs(path)
+    except OSError as exc:  # Python >2.5
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise


### PR DESCRIPTION
We've been bundling packages containing all of our rest api's and would like to generate documentation for them alongside with all of the sphinx/doxygen docs.

This bundle lets us do that.
- Parses the package looking for any swagger yaml's
- Dumps the basic swagger html/js files in place
- Template substitutions for name and yaml-json content into the index html
- Presto, done!
