### PR TITLE
 enable linking to documentation hosted on third party server 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,3 +7,4 @@ catkin_package()
 install(FILES DESTINATION ${CATKIN_PROJECT_SHARE_DESTINATION}/cmake)
 
 catkin_python_setup()
+catkin_add_nosetests(test/test_doxygenator.py)

--- a/src/rosdoc_lite/doxygenator.py
+++ b/src/rosdoc_lite/doxygenator.py
@@ -123,20 +123,26 @@ def prepare_tagfiles(tagfile_spec, tagfile_dir, output_subfolder):
                 tagfile = open(tagfile_path, 'w')
                 tagfile.write(ret.read())
                 tagfile.close()
-                tagfile_string += "%s=%s " % (tagfile_path, get_relative_doc_path(output_subfolder, tag_pair))
+                tagfile_string += "%s=%s " % (tagfile_path, get_doc_path(output_subfolder, tag_pair))
             except (urllib2.URLError, urllib2.HTTPError) as e:
                 print("Could not fetch the tagfile from %s, skipping" % tag_pair['location'], file=sys.stderr)
                 continue
         elif tag_pair['location'].find("file://") == 0:
             tagfile_path = tag_pair['location'][7:]
-            tagfile_string += "%s=%s " % (tagfile_path, get_relative_doc_path(output_subfolder, tag_pair))
+            tagfile_string += "%s=%s " % (tagfile_path, get_doc_path(output_subfolder, tag_pair))
         else:
             print("Tagfile location only supports http// and file:// prefixes, but you specify %s, skipping" % tag_pair['location'],
                   file=sys.stderr)
     return tagfile_string
 
 
-def get_relative_doc_path(output_subfolder, tag_pair):
+def get_doc_path(output_subfolder, tag_pair):
+    """Gets path from output_subfolder to url of tag_pair
+
+    If the url is a relative path from the root of documentation, the resulting
+    path will be relative to the output_subfolder, otherwise the absolute url
+    will be returned.
+    """
     path = tag_pair['docs_url']
     # prefix the path with as many .. as the output_subfolder is deep
     if not path.startswith('http://') and not path.startswith('https://'):

--- a/src/rosdoc_lite/doxygenator.py
+++ b/src/rosdoc_lite/doxygenator.py
@@ -139,14 +139,15 @@ def prepare_tagfiles(tagfile_spec, tagfile_dir, output_subfolder):
 def get_relative_doc_path(output_subfolder, tag_pair):
     path = tag_pair['docs_url']
     # prefix the path with as many .. as the output_subfolder is deep
-    if output_subfolder != '.':
-        output_subfolder_level = len(output_subfolder.split('/'))
-        reverse_output_subfolder = output_subfolder_level * ['..']
-        reverse_output_subfolder = os.path.join(*reverse_output_subfolder)
-        path = os.path.join(reverse_output_subfolder, path)
-    # append generator specific output folder
-    if 'doxygen_output_folder' in tag_pair:
-        path = os.path.join(path, tag_pair['doxygen_output_folder'])
+    if not path.startswith('http://') and not path.startswith('https://'):
+        if output_subfolder != '.':
+            output_subfolder_level = len(output_subfolder.split('/'))
+            reverse_output_subfolder = output_subfolder_level * ['..']
+            reverse_output_subfolder = os.path.join(*reverse_output_subfolder)
+            path = os.path.join(reverse_output_subfolder, path)
+        # append generator specific output folder
+        if 'doxygen_output_folder' in tag_pair:
+            path = os.path.join(path, tag_pair['doxygen_output_folder'])
     return path
 
 

--- a/src/rosdoc_lite/doxygenator.py
+++ b/src/rosdoc_lite/doxygenator.py
@@ -151,9 +151,9 @@ def get_doc_path(output_subfolder, tag_pair):
             reverse_output_subfolder = output_subfolder_level * ['..']
             reverse_output_subfolder = os.path.join(*reverse_output_subfolder)
             path = os.path.join(reverse_output_subfolder, path)
-        # append generator specific output folder
-        if 'doxygen_output_folder' in tag_pair:
-            path = os.path.join(path, tag_pair['doxygen_output_folder'])
+    # append generator specific output folder
+    if 'doxygen_output_folder' in tag_pair:
+        path = os.path.join(path, tag_pair['doxygen_output_folder'])
     return path
 
 

--- a/test/test_doxygenator.py
+++ b/test/test_doxygenator.py
@@ -1,0 +1,23 @@
+import unittest
+from rosdoc_lite import doxygenator as doxy
+
+class TestGetDocPath(unittest.TestCase):
+
+    def test_relative_doc_path(self):
+        tag_pair = {'docs_url':"relative/path"}
+        output = doxy.get_doc_path("sub/folders", tag_pair)
+        self.assertEqual("../../relative/path", output)
+
+        tag_pair = {'docs_url':"relative/path",'doxygen_output_folder':"doxygen_output_folder"}
+        output = doxy.get_doc_path("sub/folders", tag_pair)
+        self.assertEqual("../../relative/path/doxygen_output_folder", output)
+
+    def test_absolute_doc_path(self):
+        tag_pair = {'docs_url': "https://absolu.te/path"}
+        output = doxy.get_doc_path("sub/folders", tag_pair)
+        self.assertEqual("https://absolu.te/path", output)
+
+        tag_pair = {'docs_url': "https://absolu.te/path",'doxygen_output_folder':"doxygen_output_folder"}
+        output = doxy.get_doc_path("sub/folders", tag_pair)
+        self.assertEqual("https://absolu.te/path/doxygen_output_folder", output)
+


### PR DESCRIPTION
Rosdoc_lite supports external tag files, but unlike written in [ros wiki](http://wiki.ros.org/rosdoc_lite#line-189) absolute urls are not supported, because the value of 'docs_url' is always interpreted as relative path.
Now there is a check whether the url is absolute (begins with http:// or https://) or not.

