### PR TITLE
fix import

### DIFF
--- a/src/rosdoc_lite/__init__.py
+++ b/src/rosdoc_lite/__init__.py
@@ -49,7 +49,7 @@ from . import doxygenator
 
 import rospkg
 
-from catkin_pkg import packages
+from catkin_pkg import package
 
 
 def get_optparse(name):
@@ -238,7 +238,7 @@ def main():
 def get_pkg_desc(path):
     #Check whether we've got a catkin or non-catkin package
     if is_catkin(path):
-        pkg_desc = packages.parse_package(path)
+        pkg_desc = package.parse_package(path)
         print("Documenting a catkin package")
     else:
         rp = rospkg.RosPack()


### PR DESCRIPTION
As of https://github.com/ros-infrastructure/catkin_pkg/pull/171/files#diff-881522bb0a022aef976784a4d7855226 the import is not available anymore. Instead use the actual location where the function is defined.