### PR TITLE
remove unsupported option latex_paper_size

### DIFF
--- a/src/rosdoc_lite/sphinxenator.py
+++ b/src/rosdoc_lite/sphinxenator.py
@@ -63,7 +63,7 @@ def generate_sphinx(path, package, manifest, rd_config, output_dir, quiet):
                 print ("Sphinx python path is: %s" % env['PYTHONPATH'])
 
                 html_dir = os.path.join(oldcwd, output_dir, rd_config.get('output_dir', '.'))
-                command = ['sphinx-build', '-a', '-E', '-b', 'html', '-D', 'latex_paper_size=letter', '.', html_dir]
+                command = ['sphinx-build', '-a', '-E', '-b', 'html', '.', html_dir]
                 print("sphinx-building %s [%s]" % (package, ' '.join(command)))
                 print("  cwd is", os.getcwd())
                 com = Popen(command, stdout=PIPE, env=env).communicate()


### PR DESCRIPTION
The configuration variable was [removed](https://github.com/sphinx-doc/sphinx/commit/d0c202da59445bf3a3149b79f557279a1cec450e) in Sphinx 1.6. Since I don't see why it was passed in the first place I just removed it:

Before: [![Build Status](http://build.ros.org/buildStatus/icon?job=Mdoc__catkin__ubuntu_bionic_amd64&build=3)](http://build.ros.org/job/Mdoc__catkin__ubuntu_bionic_amd64/3/)
After: [![Build Status](http://build.ros.org/buildStatus/icon?job=Mdoc__catkin__ubuntu_bionic_amd64&build=4)](http://build.ros.org/job/Mdoc__catkin__ubuntu_bionic_amd64/4/)