### PR TITLE
add use_mdfile_as_mainpage option

### DIFF
--- a/src/rosdoc_lite/doxygenator.py
+++ b/src/rosdoc_lite/doxygenator.py
@@ -194,6 +194,7 @@ def package_doxygen_template(template, rd_config, path, package, html_dir, heade
               '$SEARCHENGINE': rd_config.get('searchengine', 'NO'),
               '$TAB_SIZE': rd_config.get('tab_size', '8'),
               '$TAGFILES': tagfiles,
+              '$USE_MDFILE_AS_MAINPAGE': rd_config.get('use_mdfile_as_mainpage', '')
               }
     return rdcore.instantiate_template(template, dvars)
 

--- a/src/rosdoc_lite/templates/doxy.template
+++ b/src/rosdoc_lite/templates/doxy.template
@@ -879,7 +879,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = $USE_MDFILE_AS_MAINPAGE
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing


### PR DESCRIPTION
This makes it possible/easier to use a markdown file as mainpage, e.g. the README.md

To use it, add a rosdoc.yaml with
```
- builder: doxygen
  file_patterns: '*.c *.cpp *.h *.cc *.hh *.dox *.md'
  use_mdfile_as_mainpage: README.md
```

Description of this option from Doxygen:

If the USE_MDFILE_AS_MAINPAGE tag refers to the name of a markdown file that
is part of the input, its contents will be placed on the main page
(index.html). This can be useful if you have a project on for instance GitHub
and want to reuse the introduction page also for the doxygen output.