### PR TITLE
fix top bar on recent doxygen versions

### DIFF
--- a/src/rosdoc_lite/templates/header.html
+++ b/src/rosdoc_lite/templates/header.html
@@ -2,6 +2,7 @@
 <title>$package: $title</title>
 <link href="$relpath$doxygen.css" rel="stylesheet" type="text/css">
 <link href="$relpath$tabs.css" rel="stylesheet" type="text/css">
+<script type="text/javascript" src="$relpath$jquery.js"></script>
 $search
 
 </head>


### PR DESCRIPTION
* on recent doxygen topbar requires jquery
* fixes documentation generation on ROS melodic
* see https://www.stack.nl/~dimitri/doxygen/manual/changelog.html#log_1_8_1

We need to trigger doc jobs for ROS melodic to fix documentation on the wiki after this is merged.