### PR TITLE
Update exception handling to Python2.6+ / Python3 syntax

### DIFF
--- a/src/rosdoc_lite/__init__.py
+++ b/src/rosdoc_lite/__init__.py
@@ -190,7 +190,7 @@ def generate_docs(path, package, manifest, output_dir, tagfile, generate_tagfile
         if plugin_name in build_params:
             try:
                 plugin(path, package, manifest, build_params[plugin_name], html_dir, quiet)
-            except Exception, e:
+            except Exception as e:
                 traceback.print_exc()
                 print("plugin [%s] failed" % (plugin_name), file=sys.stderr)
 

--- a/src/rosdoc_lite/doxygenator.py
+++ b/src/rosdoc_lite/doxygenator.py
@@ -254,7 +254,7 @@ def generate_doxygen(path, package, manifest, rd_config, output_dir, quiet):
         shutil.copyfile(dstyles_in, dstyles_css)
         """
 
-    except Exception, e:
+    except Exception as e:
         print("ERROR: Doxygen of package [%s] failed: %s" % (package, str(e)), file=sys.stderr)
         #make sure to pass the exception up the stack
         raise

--- a/src/rosdoc_lite/epyenator.py
+++ b/src/rosdoc_lite/epyenator.py
@@ -83,6 +83,6 @@ def generate_epydoc(path, package, manifest, rd_config, output_dir, quiet):
         print(e.output, file=sys.stderr)
         print("Unable to generate epydoc for [%s]. The return code is %d" % (package, e.returncode), file=sys.stderr)
         raise
-    except Exception, e:
+    except Exception as e:
         print("Unable to generate epydoc for [%s]. This is probably because epydoc is not installed.\nThe exact error is:\n\t%s" % (package, str(e)), file=sys.stderr)
         raise

--- a/src/rosdoc_lite/landing_page.py
+++ b/src/rosdoc_lite/landing_page.py
@@ -134,6 +134,6 @@ def generate_landing_page(package, manifest, rd_configs, output_dir):
         with open(os.path.join(html_dir, 'index.html'), 'w') as f:
             f.write(rdcore.instantiate_template(template, tempvars))
 
-    except Exception, e:
+    except Exception as e:
         print("Unable to generate landing_page for [%s]:\n\t%s" % (package, str(e)), file=sys.stderr)
         raise

--- a/src/rosdoc_lite/msgenator.py
+++ b/src/rosdoc_lite/msgenator.py
@@ -251,7 +251,7 @@ def generate_msg_docs(package, path, manifest, output_dir):
                 #print("writing", file_p)
                 f.write(text)
             msg_success.append(m)
-        except Exception, e:
+        except Exception as e:
             print("FAILED to generate for %s/%s: %s" % (package, m, str(e)), file=sys.stderr)
 
     # create dir for srv documentation
@@ -269,7 +269,7 @@ def generate_msg_docs(package, path, manifest, output_dir):
                 #print("writing", file_p)
                 f.write(text)
             srv_success.append(s)
-        except Exception, e:
+        except Exception as e:
             print("FAILED to generate for %s/%s: %s" % (package, s, str(e)), file=sys.stderr)
             raise
 
@@ -288,7 +288,7 @@ def generate_msg_docs(package, path, manifest, output_dir):
                 #print("writing", file_p)
                 f.write(text)
             action_success.append(a)
-        except Exception, e:
+        except Exception as e:
             print("FAILED to generate for %s/%s: %s" % (package, a, str(e)), file=sys.stderr)
             raise
 


### PR DESCRIPTION
Fix for https://github.com/ros-infrastructure/rosdoc_lite/issues/83