### PR TITLE
use yaml.safe_load for untrusted yaml input

### DIFF
--- a/src/rosdoc_lite/__init__.py
+++ b/src/rosdoc_lite/__init__.py
@@ -85,13 +85,13 @@ def load_rd_config(path, manifest):
                 exported_config = exported_config.replace('${prefix}', path)
                 config_path = os.path.join(path, exported_config)
                 with open(config_path, 'r') as config_file:
-                    rd_config = yaml.load(config_file)
+                    rd_config = yaml.safe_load(config_file)
             except Exception as e:
                 sys.stderr.write("ERROR: unable to load rosdoc config file [%s]: %s\n" % (config_path, str(e)))
     #we'll check if a 'rosdoc.yaml' file exists in the directory
     elif os.path.isfile(os.path.join(path, 'rosdoc.yaml')):
         with open(os.path.join(path, 'rosdoc.yaml'), 'r') as config_file:
-            rd_config = yaml.load(config_file)
+            rd_config = yaml.safe_load(config_file)
 
     return rd_config
 

--- a/src/rosdoc_lite/doxygenator.py
+++ b/src/rosdoc_lite/doxygenator.py
@@ -106,7 +106,7 @@ def prepare_tagfiles(tagfile_spec, tagfile_dir, output_subfolder):
     """A function that will load a tagfile from either a URL or the filesystem"""
     tagfile_list = []
     with open(tagfile_spec) as f:
-        tagfile_list = yaml.load(f)
+        tagfile_list = yaml.safe_load(f)
     tagfile_string = ""
     for tag_pair in tagfile_list:
         print(tag_pair)


### PR DESCRIPTION
The patch only updates the invocation where untrusted sources are being processed.