### PR TITLE
fix cmake failure when building without tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,4 +7,8 @@ catkin_package()
 install(FILES DESTINATION ${CATKIN_PROJECT_SHARE_DESTINATION}/cmake)
 
 catkin_python_setup()
-catkin_add_nosetests(test/test_doxygenator.py)
+
+if(CATKIN_ENABLE_TESTING)
+  catkin_add_nosetests(test/test_doxygenator.py)
+endif()
+


### PR DESCRIPTION
If `-DCATKIN_ENABLE_TESTING=0` is set during cmakeing the call to `catkin_add_nosetests(...)` fails. 
This is fixed by checking if testing is enabled.

closes #86