### PR TITLE
Removes obsolete doxygen options

### DIFF
--- a/src/rosdoc_lite/templates/doxy.template
+++ b/src/rosdoc_lite/templates/doxy.template
@@ -1789,18 +1789,6 @@ GENERATE_XML           = NO
 
 XML_OUTPUT             = xml
 
-# The XML_SCHEMA tag can be used to specify a XML schema, which can be used by a
-# validating XML parser to check the syntax of the XML files.
-# This tag requires that the tag GENERATE_XML is set to YES.
-
-XML_SCHEMA             =
-
-# The XML_DTD tag can be used to specify a XML DTD, which can be used by a
-# validating XML parser to check the syntax of the XML files.
-# This tag requires that the tag GENERATE_XML is set to YES.
-
-XML_DTD                =
-
 # If the XML_PROGRAMLISTING tag is set to YES doxygen will dump the program
 # listings (including syntax highlighting and cross-referencing information) to
 # the XML output. Note that enabling this will significantly increase the size


### PR DESCRIPTION
* See https://github.com/doxygen/doxygen/commit/ba31ee73aad3bdc6b3854add2db01c302c9cf19c

A bit related to my comment: https://github.com/ros-infrastructure/rosdoc_lite/issues/63#issuecomment-539451814