### PR TITLE
backwards-compatible fix for python3 API changes

### DIFF
--- a/src/rosdoc_lite/landing_page.py
+++ b/src/rosdoc_lite/landing_page.py
@@ -82,7 +82,7 @@ def generate_links(package, manifest, rd_configs):
     :param rd_configs: [dict] package manifest rosdoc configs
     :returns: [str] list of html snippets
     """
-    config_list = [c for c in rd_configs.itervalues() if c['builder'] != 'rosmake']
+    config_list = [c for c in rd_configs.values() if c['builder'] != 'rosmake']
     output_dirs = [output_location(c) for c in config_list]
     # filter out empties
     output_dirs = [d for d in output_dirs if d and d != '.']

--- a/src/rosdoc_lite/msgenator.py
+++ b/src/rosdoc_lite/msgenator.py
@@ -32,7 +32,10 @@
 
 from __future__ import print_function
 
-import cStringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 import os
 import sys
 import time
@@ -104,7 +107,7 @@ def _generate_raw_text(raw_text):
 
 def _generate_msg_text_from_spec(package, spec, msg_context, buff=None, indent=0):
     if buff is None:
-        buff = cStringIO.StringIO()
+        buff = StringIO()
     for c in spec.constants:
         buff.write("%s%s %s=%s<br />" % ("&nbsp;"*indent, c.type, c.name, c.val_text))
     for type_, name in zip(spec.types, spec.names):

--- a/src/rosdoc_lite/rdcore.py
+++ b/src/rosdoc_lite/rdcore.py
@@ -150,6 +150,6 @@ def instantiate_template(tmpl, tempvars):
     """
     looks up file within rosdoc_lite package, return its content, may sys.exit on error
     """
-    for k, v in tempvars.iteritems():
+    for k, v in tempvars.items():
         tmpl = tmpl.replace(k, kitchen.text.converters.to_unicode(v))
     return tmpl


### PR DESCRIPTION
This fixes the remaining issues coming up when generating https://github.com/ros-planning/moveit_tutorials .

It would be nice to see a melodic release for these fixes.