### PR TITLE
add generate_treeview option

### DIFF
--- a/src/rosdoc_lite/doxygenator.py
+++ b/src/rosdoc_lite/doxygenator.py
@@ -178,7 +178,7 @@ def package_doxygen_template(template, rd_config, path, package, html_dir, heade
             os.makedirs(generate_dir)
 
     print("Generated the following tagfile string %s" % tagfiles)
-    
+
     mdfile = rd_config.get('use_mdfile_as_mainpage', '')
     if mdfile:
         mdfile = os.path.join(path, mdfile)
@@ -193,6 +193,7 @@ def package_doxygen_template(template, rd_config, path, package, html_dir, heade
               '$EXTRACT_ALL': rd_config.get('extract_all', 'YES'),
               '$FILE_PATTERNS': rd_config.get('file_patterns', file_patterns),
               '$GENERATE_TAGFILE': generate_tagfile,
+              '$GENERATE_TREEVIEW': rd_config.get('generate_treeview', 'NO'),
               '$GENERATE_QHP': rd_config.get('generate_qhp', 'NO'),
               '$HTML_FOOTER': footer_filename,
               '$HTML_HEADER': header_filename,

--- a/src/rosdoc_lite/templates/doxy.template
+++ b/src/rosdoc_lite/templates/doxy.template
@@ -1352,7 +1352,7 @@ DISABLE_INDEX          = NO
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-GENERATE_TREEVIEW      = NO
+GENERATE_TREEVIEW      = $GENERATE_TREEVIEW
 
 # The ENUM_VALUES_PER_LINE tag can be used to set the number of enum values that
 # doxygen will group on one line in the generated HTML documentation.


### PR DESCRIPTION
To enable the treeview set in rosdoc.yaml
```
- builder: doxygen
  generate_treeview: YES
```