### PR TITLE
Bump CMake version to avoid CMP0048

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0.2)
 project(rosdoc_lite)
 find_package(catkin REQUIRED)
 


### PR DESCRIPTION
This bumps the minimum CMake version to 3.0.2, which is the [minimum supported by ROS Kinetic](https://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021) and new enough to default to the NEW behavior of [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html). This avoids a CMake warning when building and testing this package in Debian Buster and Ubuntu Focal.

Should fix: http://build.ros.org/view/Ndev/job/Ndev__rosdoc_lite__ubuntu_focal_amd64/1/warnings2Result/new/

ros/catkin#1052