### PR TITLE
Add missing graphviz dep

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -25,6 +25,7 @@
   <exec_depend>doxygen</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">epydoc</exec_depend>
   <exec_depend>genmsg</exec_depend>
+  <exec_depend>graphviz</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-catkin-pkg-modules</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-catkin-pkg-modules</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-kitchen</exec_depend>


### PR DESCRIPTION
Used by Doxygen for inheritance diagrams.

Partial solution for https://github.com/ros/geometry2/issues/498#issuecomment-781654088, as the issues mixes both CPP and python documentation issues.