### PR TITLE
Add support for configuring INPUT_FILTER doxygen option

### DIFF
--- a/src/rosdoc_lite/doxygenator.py
+++ b/src/rosdoc_lite/doxygenator.py
@@ -200,6 +200,7 @@ def package_doxygen_template(template, rd_config, path, package, html_dir, heade
               '$IMAGE_PATH': rd_config.get('image_path', path), #default to $INPUT
               '$INCLUDE_PATH': rd_config.get('include_path', ''),
               '$INPUT': ' '.join([path, mdfile]),
+              '$INPUT_FILTER': rd_config.get('input_filter', ''),
               '$PROJECT_NAME': package,
               '$JAVADOC_AUTOBRIEF': rd_config.get('javadoc_autobrief', 'NO'),
               '$MULTILINE_CPP_IS_BRIEF': rd_config.get('multiline_cpp_is_brief', 'NO'),


### PR DESCRIPTION
I need this option for a little transformation of my code so that Doxygen understands it better.

In particular, I need to set:

    INPUT_FILTER           =  "sed 's/\([ <]\)::/\1/g'"

This removes the global namespace designator from all elements. I.e. `::std::string` will become `std::string`. In the headers, I chose to designate all symbols with the global namespace (to avoid possible errors when someone does a `using namespace`), but Doxygen is very much confused by these, complaining a lot about unmatched function signatures that differ just in `::std::string` vs `std::string`.