### PR TITLE
Add option "required" to builder configs which will cause rosdoc_lite to fail if the builder fails.

### DIFF
--- a/rosdoc.yaml
+++ b/rosdoc.yaml
@@ -1,2 +1,3 @@
  - builder: sphinx
    sphinx_root_dir: doc
+   required: True

--- a/src/rosdoc_lite/__init__.py
+++ b/src/rosdoc_lite/__init__.py
@@ -157,6 +157,7 @@ def generate_docs(path, package, manifest, output_dir, tagfile, generate_tagfile
     Generates API docs by invoking plugins with context
 
     :returns: a list of filenames/paths that is the union set of all results of plugin invocations
+    :raises Exception: If any builder raises an exception and it has `'required': True` in build_params.
     """
     plugins = [
         ('doxygen', doxygenator.generate_doxygen),

--- a/src/rosdoc_lite/__init__.py
+++ b/src/rosdoc_lite/__init__.py
@@ -194,7 +194,7 @@ def generate_docs(path, package, manifest, output_dir, tagfile, generate_tagfile
             except Exception as e:
                 traceback.print_exc()
                 print("plugin [%s] failed" % (plugin_name), file=sys.stderr)
-                failed_plugins += [(plugin_name, e)]
+                failed_plugins.append((plugin_name, e))
 
     #Generate a landing page for the package, requires passing all the build_parameters on
     landing_page.generate_landing_page(package, manifest, build_params, html_dir)

--- a/src/rosdoc_lite/doxygenator.py
+++ b/src/rosdoc_lite/doxygenator.py
@@ -35,6 +35,7 @@ from __future__ import with_statement
 from __future__ import print_function
 
 import os
+import subprocess
 import sys
 from subprocess import Popen, PIPE
 import tempfile
@@ -48,10 +49,13 @@ def run_doxygen(package, doxygen_file, quiet=False):
     try:
         command = ['doxygen', doxygen_file]
         if quiet:
-            Popen(command, stdout=PIPE, stderr=PIPE).communicate()
+            process = Popen(command, stdout=PIPE, stderr=PIPE)
         else:
             print("doxygen-ating %s [%s]" % (package, ' '.join(command)))
-            Popen(command, stdout=PIPE).communicate()
+            process = Popen(command, stdout=PIPE)
+        com = process.communicate()
+        if process.returncode != 0:
+            raise subprocess.CalledProcessError(process.returncode, command, com[0])
     except OSError:
         #fatal
         print("""\nERROR: It appears that you do not have doxygen installed.

--- a/src/rosdoc_lite/sphinxenator.py
+++ b/src/rosdoc_lite/sphinxenator.py
@@ -34,6 +34,7 @@
 from __future__ import print_function
 
 import os
+import subprocess
 import sys
 from . import python_paths
 from subprocess import Popen, PIPE
@@ -66,11 +67,16 @@ def generate_sphinx(path, package, manifest, rd_config, output_dir, quiet):
                 command = ['sphinx-build', '-a', '-E', '-b', 'html', '.', html_dir]
                 print("sphinx-building %s [%s]" % (package, ' '.join(command)))
                 print("  cwd is", os.getcwd())
-                com = Popen(command, stdout=PIPE, env=env).communicate()
+                process = Popen(command, stdout=PIPE, stderr=PIPE, env=env)
+                com = process.communicate()
                 print('stdout:')
                 print(com[0])
                 print('stderr')
                 print(com[1])
+                print('return code')
+                print(process.returncode)
+                if process.returncode != 0:
+                    raise subprocess.CalledProcessError(process.returncode, command, output=com[0])
             finally:
                 # restore cwd
                 os.chdir(oldcwd)


### PR DESCRIPTION
Resolves #63.

Each builder gets an optional parameter `required`. If set to True, rosdoc_lite will fail if the builder failed. However, all other builders are given the option to finish their run before rosdoc_lite is exited, so that as much documentation is generated as possible.

I've set the parameter to default to False so that the feature is opt-in. This should leave all existing packages without a change, but new packages are allowed to opt in. We could also change the documentation to consistently add `required: True` in the examples, with the note that it can be turned off.

@tfoote Would this be a good approach?